### PR TITLE
Debug AttributeError in NDlib.ipynb

### DIFF
--- a/NDlib.ipynb
+++ b/NDlib.ipynb
@@ -5864,7 +5864,7 @@
     "import ndlib.models.compartments.NodeStochastic as ns\n",
     "\n",
     "# Compartment description\n",
-    "c1 = ns.NodeStochastic(0.02, triggering_status=\"Infected\")\n",
+    "c1 = ns(0.02, triggering_status=\"Infected\")\n",
     "\n",
     "# Rule definition\n",
     "model.add_rule(\"Susceptible\", \"Infected\", c1)"


### PR DESCRIPTION
This code chunk
```py
import ndlib.models.compartments.NodeStochastic as ns
c1 = ns.NodeStochastic(0.02, triggering_status="Infected")
```
yields 
```py 
AttributeError: type object 'NodeStochastic' has no attribute 'NodeStochastic'
```

It's debugged as follows
```py
import ndlib.models.compartments.NodeStochastic as ns
c1 = ns(0.02, triggering_status="Infected")
```

Thank you very much for making this wonderful tutorials publicly available! 