### PR TITLE
Update NDlib.ipynb

### DIFF
--- a/NDlib.ipynb
+++ b/NDlib.ipynb
@@ -5987,7 +5987,7 @@
     "c3 = cd.CountDown(\"incubation\", iterations=10)\n",
     "\n",
     "# Rule definition\n",
-    "model.add_rule(\"Recovered\", \"Susceptible\", c1)"
+    "model.add_rule(\"Recovered\", \"Susceptible\", c3)"
    ]
   },
   {


### PR DESCRIPTION
Fix typo in the countdown object name when passed to `add_rule`.